### PR TITLE
Fix tests on zig latest version, add 2 tests.

### DIFF
--- a/test.zig
+++ b/test.zig
@@ -1,9 +1,27 @@
-const zlm = @import("zlm.zig");
+const std = @import("std");
+const math = @import("zlm.zig");
+const assert = std.debug.assert;
 
-const assert = @import("std").debug.assert;
+const vec2 = math.vec2;
+const vec3 = math.vec3;
+const vec4 = math.vec4;
 
-comptime {
-    @import("std").testing.refAllDecls(zlm);
+const Vec2 = math.Vec2;
+const Vec3 = math.Vec3;
+const Vec4 = math.Vec4;
+
+const Mat3 = math.Mat3;
+const Mat4 = math.Mat4;
+
+test "default generic is f32" {
+    const T = @TypeOf(vec2(1,2).x);
+    try std.testing.expectEqual(T, f32);
+}
+
+test "SpecializeOn()" {
+    const math_u64 = math.SpecializeOn(u64);
+    const T = @TypeOf(math_u64.vec2(3,4).x);
+    try std.testing.expectEqual(T, u64);
 }
 
 test "constructors" {


### PR DESCRIPTION
Thanks for creating zlm!. When running `zig test test.zig` with 0.10-dev, I get these errors:

```
test.zig:10:16: error: use of undeclared identifier 'vec2'
    const v2 = vec2(1, 2);
               ^
test.zig:27:15: error: use of undeclared identifier 'vec2'
    const a = vec2(2, 1);
              ^
test.zig:44:15: error: use of undeclared identifier 'vec3'
    const a = vec3(2, 1, 3);
              ^
test.zig:63:15: error: use of undeclared identifier 'vec4'
    const a = vec4(2, 1, 4, 3);
              ^
test.zig:80:15: error: use of undeclared identifier 'vec3'
    const v = vec3(1, 2, 3);
              ^
test.zig:95:16: error: use of undeclared identifier 'Mat4'
    const id = Mat4.identity;
               ^
test.zig:178:17: error: use of undeclared identifier 'Mat4'
    const mat = Mat4{
                ^
test.zig:208:12: error: use of undeclared identifier 'std'
    assert(std.meta.eql(vec4(0, 1, 1, 2), vec2(1, 2).swizzle("0x1y")));
           ^
test.zig:213:12: error: use of undeclared identifier 'std'
    assert(std.meta.eql(vec4(1, 1, 2, 3), vec3(1, 2, 3).swizzle("xxyz")));
           ^
test.zig:218:12: error: use of undeclared identifier 'std'
    assert(std.meta.eql(vec4(3, 4, 2, 1), vec4(1, 2, 3, 4).swizzle("zwyx")));
```    

This PR fixes the tests, and also adds 2 new tests.

```
$ zig version
0.10.0-dev.2214+5087ec6f4
```

## Unresolved 

I removed the call to refAllDecls as it did not seem to actually have any effect? It seems that refAllDecls does not work with the default specialization, or something. I was pretty puzzled over this, and just punted and manually assigned const's for the `vec2, vec3, vec4, etc` at the top of the test.zig

```zig
comptime {
    @import("std").testing.refAllDecls(zlm);
}
```