### PR TITLE
Fix stage3 compile errors

### DIFF
--- a/zlm-generic.zig
+++ b/zlm-generic.zig
@@ -218,7 +218,7 @@ pub fn SpecializeOn(comptime Real: type) type {
             pub const unitX = Self.new(1, 0);
             pub const unitY = Self.new(0, 1);
 
-            usingnamespace VectorMixin(Self);
+            pub usingnamespace VectorMixin(Self);
 
             pub fn new(x: Real, y: Real) Self {
                 return Self{
@@ -273,7 +273,7 @@ pub fn SpecializeOn(comptime Real: type) type {
             pub const unitY = Self.new(0, 1, 0);
             pub const unitZ = Self.new(0, 0, 1);
 
-            usingnamespace VectorMixin(Self);
+            pub usingnamespace VectorMixin(Self);
 
             pub fn new(x: Real, y: Real, z: Real) Self {
                 return Self{
@@ -379,7 +379,7 @@ pub fn SpecializeOn(comptime Real: type) type {
             pub const unitZ = Self.new(0, 0, 1, 0);
             pub const unitW = Self.new(0, 0, 0, 1);
 
-            usingnamespace VectorMixin(Self);
+            pub usingnamespace VectorMixin(Self);
 
             pub fn new(x: Real, y: Real, z: Real, w: Real) Self {
                 return Self{

--- a/zlm.zig
+++ b/zlm.zig
@@ -13,4 +13,4 @@ pub fn toDegrees(rad: anytype) @TypeOf(rad) {
 }
 
 // export all vectors by-default to f32
-usingnamespace SpecializeOn(f32);
+pub usingnamespace SpecializeOn(f32);


### PR DESCRIPTION
This PR fixes an issue with zlm keeping it from compiling on stage3. The issue is that mixins didn't have their `usingnamespace` declarations marked public so on stage3 they can't be accessed from outside. All tests still pass on stage1 and stage3 with this PR.