### PR TITLE
batchMul Bug Fix

### DIFF
--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -655,7 +655,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 if (items.len == 1)
                     return items[0];
                 var value = items[0];
-                for (0..items.len) |i| {
+                for (1..items.len) |i| {
                     value = value.mul(items[i]);
                 }
                 return value;


### PR DESCRIPTION
Fixed a bug in batchMul introduced in the "[Update for multi-for loops](https://github.com/ziglibs/zlm/commit/2dc8c0db2e92529bb618ca639bb891b6187fa579)" commit where the first matrix would be multiplied twice.