### PR TITLE
fix(mat4): small mat4 bugs

### DIFF
--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -571,7 +571,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 result.fields[1][1] = 1.0 / (tanHalfFovy);
                 result.fields[2][2] = - (far + near) / (far - near);
                 result.fields[2][3] = - 1;
-                result.fields[3][2] = -(2 * far * near) / (far - near);
+                result.fields[3][2] = - (2 * far * near) / (far - near);
                 return result;
             }
 

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -569,9 +569,9 @@ pub fn SpecializeOn(comptime Real: type) type {
                 var result = Self.zero;
                 result.fields[0][0] = 1.0 / (aspect * tanHalfFovy);
                 result.fields[1][1] = 1.0 / (tanHalfFovy);
-                result.fields[2][2] = far / (far - near);
-                result.fields[2][3] = 1;
-                result.fields[3][2] = -(far * near) / (far - near);
+                result.fields[2][2] = - (far + near) / (far - near);
+                result.fields[2][3] = - 1;
+                result.fields[3][2] = -(2 * far * near) / (far - near);
                 return result;
             }
 

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -523,10 +523,10 @@ pub fn SpecializeOn(comptime Real: type) type {
             /// Creates a look-at matrix.
             /// The matrix will create a transformation that can be used
             /// as a camera transform.
-            /// the camera is located at `eye` and will look into `center`.
+            /// the camera is located at `eye` and will look into `direction`.
             /// `up` is the direction from the screen center to the upper screen border.
-            pub fn createLook(eye: Vec3, center: Vec3, up: Vec3) Self {
-                const f = eye.sub(center).normalize();
+            pub fn createLook(eye: Vec3, direction: Vec3, up: Vec3) Self {
+                const f = direction.normalize();
                 const s = Vec3.cross(up, f).normalize();
                 const u = Vec3.cross(f, s);
 

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -579,10 +579,11 @@ pub fn SpecializeOn(comptime Real: type) type {
             pub fn createAngleAxis(axis: Vec3, angle: Real) Self {
                 const cos = @cos(angle);
                 const sin = @sin(angle);
-                const sum = axis.x + axis.y + axis.z;
-                const x = axis.x / sum;
-                const y = axis.y / sum;
-                const z = axis.z / sum;
+
+                const normalized = axis.normalize();
+                const x = normalized.x;
+                const y = normalized.y;
+                const z = normalized.z;
 
                 return Self{    
                     .fields = [4][4]Real{

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -184,6 +184,17 @@ pub fn SpecializeOn(comptime Real: type) type {
                     return result;
                 }
 
+                /// returns a new vector where each component is clamped to the given range.
+                /// `min` and `max` must be of the same type as the vector, and every field of 
+                /// `min` must be smaller or equal to the corresponding field of `max`.
+                pub fn componentClamp(a: Self, min: Self, max: Self) Self {
+                    var result: Self = undefined;
+                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                        @field(result, fld.name) = std.math.clamp(@field(a, fld.name), @field(min, fld.name), @field(max, fld.name));
+                    }
+                    return result;
+                }
+
                 /// linear interpolation between two vectors
                 /// only works on float vectors (Real must be a float)
                 pub fn lerp(a: Self, b: Self, f: Real) Self {

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -73,6 +73,15 @@ pub fn SpecializeOn(comptime Real: type) type {
                     return result;
                 }
 
+                /// returns the negative of self
+                pub fn neg(self: Self) Self {
+                    var result: Self = undefined;
+                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                        @field(result, fld.name) = - @field(self, fld.name);
+                    }
+                    return result;
+                }
+
                 /// returns the dot product of two vectors.
                 /// This is the sum of products of all components.
                 pub fn dot(a: Self, b: Self) Real {

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -527,8 +527,8 @@ pub fn SpecializeOn(comptime Real: type) type {
             /// `up` is the direction from the screen center to the upper screen border.
             pub fn createLook(eye: Vec3, direction: Vec3, up: Vec3) Self {
                 const f = direction.normalize();
-                const s = Vec3.cross(up, f).normalize();
-                const u = Vec3.cross(f, s);
+                const s = Vec3.cross(f, up).normalize();
+                const u = Vec3.cross(s, f);
 
                 var result = Self.identity;
                 result.fields[0][0] = s.x;
@@ -537,12 +537,12 @@ pub fn SpecializeOn(comptime Real: type) type {
                 result.fields[0][1] = u.x;
                 result.fields[1][1] = u.y;
                 result.fields[2][1] = u.z;
-                result.fields[0][2] = f.x;
-                result.fields[1][2] = f.y;
-                result.fields[2][2] = f.z;
-                result.fields[3][0] = -Vec3.dot(s, eye);
-                result.fields[3][1] = -Vec3.dot(u, eye);
-                result.fields[3][2] = -Vec3.dot(f, eye);
+                result.fields[0][2] = - f.x;
+                result.fields[1][2] = - f.y;
+                result.fields[2][2] = - f.z;
+                result.fields[3][0] = - Vec3.dot(s, eye);
+                result.fields[3][1] = - Vec3.dot(u, eye);
+                result.fields[3][2] = Vec3.dot(f, eye);
                 return result;
             }
 

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -523,10 +523,10 @@ pub fn SpecializeOn(comptime Real: type) type {
             /// Creates a look-at matrix.
             /// The matrix will create a transformation that can be used
             /// as a camera transform.
-            /// the camera is located at `eye` and will look into `direction`.
+            /// the camera is located at `eye` and will look into `center`.
             /// `up` is the direction from the screen center to the upper screen border.
-            pub fn createLook(eye: Vec3, direction: Vec3, up: Vec3) Self {
-                const f = direction.normalize();
+            pub fn createLook(eye: Vec3, center: Vec3, up: Vec3) Self {
+                const f = eye.sub(center).normalize();
                 const s = Vec3.cross(up, f).normalize();
                 const u = Vec3.cross(f, s);
 

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -579,15 +579,16 @@ pub fn SpecializeOn(comptime Real: type) type {
             pub fn createAngleAxis(axis: Vec3, angle: Real) Self {
                 const cos = @cos(angle);
                 const sin = @sin(angle);
-                const x = axis.x;
-                const y = axis.y;
-                const z = axis.z;
+                const sum = axis.x + axis.y + axis.z;
+                const x = axis.x / sum;
+                const y = axis.y / sum;
+                const z = axis.z / sum;
 
                 return Self{    
                     .fields = [4][4]Real{
-                        [4]Real{ cos + x * x * (1 - cos),       x * y * (1 - cos) - z * sin,    x * z * (1 - cos) + y * sin, 0 },
-                        [4]Real{ y * x * (1 - cos) + z * sin,   cos + y * y * (1 - cos),        y * z * (1 - cos) - x * sin, 0 },
-                        [4]Real{ z * x * (1 - cos) - y * sin,   z * y * (1 - cos) + x * sin,    cos + z * z * (1 - cos),     0 },
+                        [4]Real{ cos + x * x * (1 - cos),       x * y * (1 - cos) + z * sin,    x * z * (1 - cos) - y * sin, 0 },
+                        [4]Real{ y * x * (1 - cos) - z * sin,   cos + y * y * (1 - cos),        y * z * (1 - cos) + x * sin, 0 },
+                        [4]Real{ z * x * (1 - cos) + y * sin,   z * y * (1 - cos) - x * sin,    cos + z * z * (1 - cos),     0 },
                         [4]Real{ 0,                             0,                              0,                           1 },
                     },
                 };

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -577,18 +577,18 @@ pub fn SpecializeOn(comptime Real: type) type {
 
             /// creates a rotation matrix around a certain axis.
             pub fn createAngleAxis(axis: Vec3, angle: Real) Self {
-                var cos = @cos(angle);
-                var sin = @sin(angle);
-                var x = axis.x;
-                var y = axis.y;
-                var z = axis.z;
+                const cos = @cos(angle);
+                const sin = @sin(angle);
+                const x = axis.x;
+                const y = axis.y;
+                const z = axis.z;
 
-                return Self{
+                return Self{    
                     .fields = [4][4]Real{
-                        [4]Real{ cos + x * x * (1 - cos), x * y * (1 - cos) - z * sin, x * z * (1 - cos) + y * sin, 0 },
-                        [4]Real{ y * x * (1 - cos) + z * sin, cos + y * y * (1 - cos), y * z * (1 - cos) - x * sin, 0 },
-                        [4]Real{ z * x * (1 * cos) - y * sin, z * y * (1 - cos) + x * sin, cos + z * z * (1 - cos), 0 },
-                        [4]Real{ 0, 0, 0, 1 },
+                        [4]Real{ cos + x * x * (1 - cos),       x * y * (1 - cos) - z * sin,    x * z * (1 - cos) + y * sin, 0 },
+                        [4]Real{ y * x * (1 - cos) + z * sin,   cos + y * y * (1 - cos),        y * z * (1 - cos) - x * sin, 0 },
+                        [4]Real{ z * x * (1 - cos) - y * sin,   z * y * (1 - cos) + x * sin,    cos + z * z * (1 - cos),     0 },
+                        [4]Real{ 0,                             0,                              0,                           1 },
                     },
                 };
             }

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -643,10 +643,10 @@ pub fn SpecializeOn(comptime Real: type) type {
                 var result = Self.identity;
                 result.fields[0][0] = 2 / (right - left);
                 result.fields[1][1] = 2 / (top - bottom);
-                result.fields[2][2] = 1 / (far - near);
-                result.fields[3][0] = -(right + left) / (right - left);
-                result.fields[3][1] = -(top + bottom) / (top - bottom);
-                result.fields[3][2] = -near / (far - near);
+                result.fields[2][2] = - 2 / (far - near);
+                result.fields[3][0] = - (right + left) / (right - left);
+                result.fields[3][1] = - (top + bottom) / (top - bottom);
+                result.fields[3][2] = - (far + near) / (far - near);
                 return result;
             }
 


### PR DESCRIPTION
This PR fixes some small bugs in the Mat4 functions:

1. The implementation of `createAngleAxis` is different from the GLM one found in https://github.com/g-truc/glm/blob/0.9.5/glm/gtc/matrix_transform.inl#L207-L229
2. Axis rotation implementation as https://github.com/g-truc/glm/blob/0.9.5/glm/gtc/matrix_transform.inl#L47