### PR TITLE
Update to compile on Zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     _ = b.addModule("zlm", .{
-        .source_file = .{ .path = "src/zlm.zig" },
+        .root_source_file = .{ .path = "src/zlm.zig" },
     });
 
     const test_exe = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = "zlm",
+    .version = "0.1.0",
+    .minimum_zig_version = "0.11.0",
+    .dependencies = .{},
+    .paths = .{
+        ".github",
+        ".gitignore",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+        "src",
+        "zig.mod",
+    },
+}

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -106,7 +106,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// returns either a normalized vector (`length() = 1`) or `zero` if the vector
                 /// has length 0.
                 pub fn normalize(vec: Self) Self {
-                    var len = vec.length();
+                    const len = vec.length();
                     return if (len != 0.0)
                         vec.scale(1.0 / vec.length())
                     else
@@ -117,7 +117,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 pub fn abs(a: Self) Self {
                     var result: Self = undefined;
                     inline for (@typeInfo(Self).Struct.fields) |fld| {
-                        @field(result, fld.name) = std.math.fabs(@field(a, fld.name));
+                        @field(result, fld.name) = @abs(@field(a, fld.name));
                     }
                     return result;
                 }
@@ -170,7 +170,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 pub fn componentMin(a: Self, b: Self) Self {
                     var result: Self = undefined;
                     inline for (@typeInfo(Self).Struct.fields) |fld| {
-                        @field(result, fld.name) = std.math.min(@field(a, fld.name), @field(b, fld.name));
+                        @field(result, fld.name) = @min(@field(a, fld.name), @field(b, fld.name));
                     }
                     return result;
                 }
@@ -179,7 +179,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 pub fn componentMax(a: Self, b: Self) Self {
                     var result: Self = undefined;
                     inline for (@typeInfo(Self).Struct.fields) |fld| {
-                        @field(result, fld.name) = std.math.max(@field(a, fld.name), @field(b, fld.name));
+                        @field(result, fld.name) = @max(@field(a, fld.name), @field(b, fld.name));
                     }
                     return result;
                 }
@@ -443,7 +443,7 @@ pub fn SpecializeOn(comptime Real: type) type {
 
             /// identitiy matrix
             pub const identity = Mat2{
-                .fields = [2]Real{
+                .fields = [2][2]Real{
                     [2]Real{ 1, 0 },
                     [2]Real{ 0, 1 },
                 },
@@ -456,7 +456,7 @@ pub fn SpecializeOn(comptime Real: type) type {
 
             /// identitiy matrix
             pub const identity = Mat3{
-                .fields = [3]Real{
+                .fields = [3][3]Real{
                     [3]Real{ 1, 0, 0 },
                     [3]Real{ 0, 1, 0 },
                     [3]Real{ 0, 0, 1 },
@@ -586,11 +586,11 @@ pub fn SpecializeOn(comptime Real: type) type {
 
             /// creates a rotation matrix around a certain axis.
             pub fn createAngleAxis(axis: Vec3, angle: Real) Self {
-                var cos = @cos(angle);
-                var sin = @sin(angle);
-                var x = axis.x;
-                var y = axis.y;
-                var z = axis.z;
+                const cos = @cos(angle);
+                const sin = @sin(angle);
+                const x = axis.x;
+                const y = axis.y;
+                const z = axis.z;
 
                 return Self{
                     .fields = [4][4]Real{


### PR DESCRIPTION
Makes a few changes to compile on Zig master (which as of now is `0.12.0-dev.2543+9eda6ccef`).
* Module `source_file` is now `root_source_file`.
* `std.math.fabs`, `std.math.min`, and `std.math.max` are now deprecated and should use builtins.
* Variables that are not mutated must now be `const`.
* Fixed a small typo in the identity matrices for `Mat2` and `Mat3`.
* Added a `build.zig.zon` for the Zig package manager just for fun.