### PR TITLE
Change row and col order in matrix multiplication

### DIFF
--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -527,9 +527,9 @@ pub fn SpecializeOn(comptime Real: type) type {
                     inline for (0..4) |col| {
                         var sum: Real = 0.0;
                         inline for (0..4) |i| {
-                            sum += a.fields[row][i] * b.fields[i][col];
+                            sum += a.fields[i][row] * b.fields[col][i];
                         }
-                        result.fields[row][col] = sum;
+                        result.fields[col][row] = sum;
                     }
                 }
                 return result;


### PR DESCRIPTION
The matrices are column major order, so the first index is the column. The function `mul` for `Mat4` actually does b * a instead of a * b because the row is used to index the column.