### PR TITLE
Update to 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,14 @@
 .{
-    .name = "zlm",
-    .version = "0.1.0",
-    .minimum_zig_version = "0.11.0",
+    .name = .zlm, // names aren't strings anymore
+    .version = "0.2.0", // to 0.2.0 since it is a breaking change
+    .minimum_zig_version = "0.14.0",
+    // When forking a Zig project, this id should be regenerated (delete the
+    // field and run `zig build`) if the upstream project is still maintained.
+    // Otherwise, the fork is *hostile*, attempting to take control over the
+    // original project's identity. Thus it is recommended to leave the comment
+    // on the following line intact, so that it shows up in code reviews that
+    // modify the field.
+    // .fingerprint = TODO(0x[16 hex digits]), // Changing this has security and trust implications.
     .dependencies = .{},
     .paths = .{
         ".github",

--- a/src/zlm-generic.zig
+++ b/src/zlm-generic.zig
@@ -22,7 +22,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// Initializes all values of the vector with the given value.
                 pub fn all(value: Real) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = value;
                     }
                     return result;
@@ -31,7 +31,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// adds all components from `a` with the components of `b`.
                 pub fn add(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @field(a, fld.name) + @field(b, fld.name);
                     }
                     return result;
@@ -40,7 +40,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// subtracts all components from `a` with the components of `b`.
                 pub fn sub(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @field(a, fld.name) - @field(b, fld.name);
                     }
                     return result;
@@ -49,7 +49,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// multiplies all components from `a` with the components of `b`.
                 pub fn mul(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @field(a, fld.name) * @field(b, fld.name);
                     }
                     return result;
@@ -58,7 +58,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// divides all components from `a` by the components of `b`.
                 pub fn div(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @field(a, fld.name) / @field(b, fld.name);
                     }
                     return result;
@@ -67,7 +67,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// multiplies all components by a scalar value.
                 pub fn scale(a: Self, b: Real) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @field(a, fld.name) * b;
                     }
                     return result;
@@ -76,8 +76,8 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// returns the negative of self
                 pub fn neg(self: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
-                        @field(result, fld.name) = - @field(self, fld.name);
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
+                        @field(result, fld.name) = -@field(self, fld.name);
                     }
                     return result;
                 }
@@ -86,7 +86,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// This is the sum of products of all components.
                 pub fn dot(a: Self, b: Self) Real {
                     var result: Real = 0;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         result += @field(a, fld.name) * @field(b, fld.name);
                     }
                     return result;
@@ -125,7 +125,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// applies component-wise absolute values
                 pub fn abs(a: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @abs(@field(a, fld.name));
                     }
                     return result;
@@ -178,7 +178,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// returns a new vector where each component is the minimum of the components of the input vectors.
                 pub fn componentMin(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @min(@field(a, fld.name), @field(b, fld.name));
                     }
                     return result;
@@ -187,18 +187,18 @@ pub fn SpecializeOn(comptime Real: type) type {
                 /// returns a new vector where each component is the maximum of the components of the input vectors.
                 pub fn componentMax(a: Self, b: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = @max(@field(a, fld.name), @field(b, fld.name));
                     }
                     return result;
                 }
 
                 /// returns a new vector where each component is clamped to the given range.
-                /// `min` and `max` must be of the same type as the vector, and every field of 
+                /// `min` and `max` must be of the same type as the vector, and every field of
                 /// `min` must be smaller or equal to the corresponding field of `max`.
                 pub fn componentClamp(a: Self, min: Self, max: Self) Self {
                     var result: Self = undefined;
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         @field(result, fld.name) = std.math.clamp(@field(a, fld.name), @field(min, fld.name), @field(max, fld.name));
                     }
                     return result;
@@ -211,7 +211,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 }
 
                 pub fn eql(a: Self, b: Self) bool {
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         if (@field(a, fld.name) != @field(b, fld.name))
                             return false;
                     }
@@ -219,7 +219,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 }
 
                 pub fn approxEqAbs(a: Self, b: Self, tolerance: Real) bool {
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         if (!std.math.approxEqAbs(Real, @field(a, fld.name), @field(b, fld.name), tolerance))
                             return false;
                     }
@@ -227,7 +227,7 @@ pub fn SpecializeOn(comptime Real: type) type {
                 }
 
                 pub fn approxEqRel(a: Self, b: Self, tolerance: Real) bool {
-                    inline for (@typeInfo(Self).Struct.fields) |fld| {
+                    inline for (@typeInfo(Self).@"struct".fields) |fld| {
                         if (!std.math.approxEqRel(Real, @field(a, fld.name), @field(b, fld.name), tolerance))
                             return false;
                     }
@@ -566,11 +566,11 @@ pub fn SpecializeOn(comptime Real: type) type {
                 result.fields[0][1] = u.x;
                 result.fields[1][1] = u.y;
                 result.fields[2][1] = u.z;
-                result.fields[0][2] = - f.x;
-                result.fields[1][2] = - f.y;
-                result.fields[2][2] = - f.z;
-                result.fields[3][0] = - Vec3.dot(s, eye);
-                result.fields[3][1] = - Vec3.dot(u, eye);
+                result.fields[0][2] = -f.x;
+                result.fields[1][2] = -f.y;
+                result.fields[2][2] = -f.z;
+                result.fields[3][0] = -Vec3.dot(s, eye);
+                result.fields[3][1] = -Vec3.dot(u, eye);
                 result.fields[3][2] = Vec3.dot(f, eye);
                 return result;
             }
@@ -598,9 +598,9 @@ pub fn SpecializeOn(comptime Real: type) type {
                 var result = Self.zero;
                 result.fields[0][0] = 1.0 / (aspect * tanHalfFovy);
                 result.fields[1][1] = 1.0 / (tanHalfFovy);
-                result.fields[2][2] = - (far + near) / (far - near);
-                result.fields[2][3] = - 1;
-                result.fields[3][2] = - (2 * far * near) / (far - near);
+                result.fields[2][2] = -(far + near) / (far - near);
+                result.fields[2][3] = -1;
+                result.fields[3][2] = -(2 * far * near) / (far - near);
                 return result;
             }
 
@@ -614,12 +614,12 @@ pub fn SpecializeOn(comptime Real: type) type {
                 const y = normalized.y;
                 const z = normalized.z;
 
-                return Self{    
+                return Self{
                     .fields = [4][4]Real{
-                        [4]Real{ cos + x * x * (1 - cos),       x * y * (1 - cos) + z * sin,    x * z * (1 - cos) - y * sin, 0 },
-                        [4]Real{ y * x * (1 - cos) - z * sin,   cos + y * y * (1 - cos),        y * z * (1 - cos) + x * sin, 0 },
-                        [4]Real{ z * x * (1 - cos) + y * sin,   z * y * (1 - cos) - x * sin,    cos + z * z * (1 - cos),     0 },
-                        [4]Real{ 0,                             0,                              0,                           1 },
+                        [4]Real{ cos + x * x * (1 - cos), x * y * (1 - cos) + z * sin, x * z * (1 - cos) - y * sin, 0 },
+                        [4]Real{ y * x * (1 - cos) - z * sin, cos + y * y * (1 - cos), y * z * (1 - cos) + x * sin, 0 },
+                        [4]Real{ z * x * (1 - cos) + y * sin, z * y * (1 - cos) - x * sin, cos + z * z * (1 - cos), 0 },
+                        [4]Real{ 0, 0, 0, 1 },
                     },
                 };
             }
@@ -672,10 +672,10 @@ pub fn SpecializeOn(comptime Real: type) type {
                 var result = Self.identity;
                 result.fields[0][0] = 2 / (right - left);
                 result.fields[1][1] = 2 / (top - bottom);
-                result.fields[2][2] = - 2 / (far - near);
-                result.fields[3][0] = - (right + left) / (right - left);
-                result.fields[3][1] = - (top + bottom) / (top - bottom);
-                result.fields[3][2] = - (far + near) / (far - near);
+                result.fields[2][2] = -2 / (far - near);
+                result.fields[3][0] = -(right + left) / (right - left);
+                result.fields[3][1] = -(top + bottom) / (top - bottom);
+                result.fields[3][2] = -(far + near) / (far - near);
                 return result;
             }
 


### PR DESCRIPTION
This is a PR to make the lib compatible with 0.14.0 (but no longer with 0.11.0-0.13.0)

The changes:
- in zlm-generics
  - replace `@typeInfo(Self).Struct` to `@typeInfo(Self).@"struct"` (breaking change of 0.14.0)
  - formating, because I used zls's auto formater
- in build.zig.zon
  - name is now an enum literal instead of a string
  - upped the version (you can correct that)
  - minimum_zig_version upped to "0.14.0"
  - a `fingerprint` must be added ! I lend this responsibility to you, as it is your project and not mine.
