### PR TITLE
`0.15.1` - Format Methods No Longer Have Format Strings or Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 zig-cache
+.zig-cache/

--- a/src/test.zig
+++ b/src/test.zig
@@ -238,3 +238,29 @@ test "vec4 swizzle" {
     assert(std.meta.eql(vec4(3, 4, 2, 1), vec4(1, 2, 3, 4).swizzle("zwyx")));
     assert(std.meta.eql(@as(f32, 3), vec4(1, 2, 3, 4).swizzle("z")));
 }
+
+test "vec2 format" {
+    try std.testing.expectFmt("vec2(1.00, 2.00)", "{f}", .{vec2(1, 2)});
+}
+
+test "vec3 format" {
+    try std.testing.expectFmt("vec3(1.00, 2.00, 3.00)", "{f}", .{vec3(1, 2, 3)});
+}
+
+test "vec4 format" {
+    try std.testing.expectFmt("vec4(1.00, 2.00, 3.00, 4.00)", "{f}", .{vec4(1, 2, 3, 4)});
+}
+
+test "mat4 format" {
+    const mat = Mat4{
+        .fields = [4][4]f32{
+            // zig fmt: off
+            [4]f32{ 1,  2,  3,  4 },
+            [4]f32{ 5,  6,  7,  8 },
+            [4]f32{ 9,  10, 11, 12 },
+            [4]f32{ 13, 14, 15, 16 },
+            // zig-fmt: on
+        },
+    };
+    try std.testing.expectFmt("mat4{ (1.00 2.00 3.00 4.00) (5.00 6.00 7.00 8.00) (9.00 10.00 11.00 12.00) (13.00 14.00 15.00 16.00) }", "{f}", .{mat});
+}

--- a/src/zlm.zig
+++ b/src/zlm.zig
@@ -255,8 +255,8 @@ pub fn as(comptime Real: type) type {
                 };
             }
 
-            pub fn format(value: Self, comptime _: []const u8, _: std.fmt.FormatOptions, stream: anytype) !void {
-                try stream.print("vec2({d:.2}, {d:.2})", .{ value.x, value.y });
+            pub fn format(this: Self, writer: *std.Io.Writer) !void {
+                try writer.print("vec2({d:.2}, {d:.2})", .{ this.x, this.y });
             }
 
             fn getField(vec: Self, comptime index: comptime_int) Real {
@@ -343,8 +343,8 @@ pub fn as(comptime Real: type) type {
                 };
             }
 
-            pub fn format(value: Self, comptime _: []const u8, _: std.fmt.FormatOptions, stream: anytype) !void {
-                try stream.print("vec3({d:.2}, {d:.2}, {d:.2})", .{ value.x, value.y, value.z });
+            pub fn format(value: Self, writer: *std.Io.Writer) !void {
+                try writer.print("vec3({d:.2}, {d:.2}, {d:.2})", .{ value.x, value.y, value.z });
             }
 
             /// calculates the cross product. result will be perpendicular to a and b.
@@ -474,8 +474,8 @@ pub fn as(comptime Real: type) type {
                 };
             }
 
-            pub fn format(value: Self, comptime _: []const u8, _: std.fmt.FormatOptions, stream: anytype) !void {
-                try stream.print("vec4({d:.2}, {d:.2}, {d:.2}, {d:.2})", .{ value.x, value.y, value.z, value.w });
+            pub fn format(value: Self, writer: *std.Io.Writer) !void {
+                try writer.print("vec4({d:.2}, {d:.2}, {d:.2}, {d:.2})", .{ value.x, value.y, value.z, value.w });
             }
 
             /// multiplies the vector with a matrix.
@@ -578,15 +578,15 @@ pub fn as(comptime Real: type) type {
                 },
             };
 
-            pub fn format(value: Self, comptime _: []const u8, _: std.fmt.FormatOptions, stream: anytype) !void {
-                try stream.writeAll("mat4{");
+            pub fn format(value: Self, writer: *std.Io.Writer) !void {
+                try writer.writeAll("mat4{");
 
                 inline for (0..4) |i| {
                     const row = value.fields[i];
-                    try stream.print(" ({d:.2} {d:.2} {d:.2} {d:.2})", .{ row[0], row[1], row[2], row[3] });
+                    try writer.print(" ({d:.2} {d:.2} {d:.2} {d:.2})", .{ row[0], row[1], row[2], row[3] });
                 }
 
-                try stream.writeAll(" }");
+                try writer.writeAll(" }");
             }
 
             /// performs matrix multiplication of a*b


### PR DESCRIPTION
## What
As part of the transition to zig 0.15.1, the language changed the function signature for `format`.

https://ziglang.org/download/0.15.1/release-notes.html#Format-Methods-No-Longer-Have-Format-Strings-or-Options

```Zig
pub fn format(
    this: @This(),
    comptime format_string: []const u8,
    options: std.fmt.FormatOptions,
    writer: anytype,
) !void { ... }
```
⬇️
```Zig
pub fn format(this: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void { ... }
```

